### PR TITLE
fix: remove obsolete lang rule settings

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -13,9 +13,6 @@ module.exports = {
   rules: {
     // Apply valid scopes and types
     'scope-enum': [scopeValidationLevel, 'always', validScopes],
-    'type-enum': [2, 'always', validTypes],
-
-    // Disable language rule
-    lang: [0, 'always', 'eng']
+    'type-enum': [2, 'always', validTypes]
   }
 };

--- a/packages/generator-semantic-module/src/generators/app/templates/commitlint-commitizen.config.js
+++ b/packages/generator-semantic-module/src/generators/app/templates/commitlint-commitizen.config.js
@@ -13,9 +13,6 @@ module.exports = {<% if (commitlintConfig) { %>
   rules: {
     // Apply valid scopes and types
     'scope-enum': [scopeValidationLevel, 'always', validScopes],
-    'type-enum': [2, 'always', validTypes],
-
-    // Disable language rule
-    lang: [0, 'always', 'eng']
+    'type-enum': [2, 'always', validTypes]
   }
 };

--- a/packages/generator-semantic-module/src/generators/app/templates/commitlint.config.js
+++ b/packages/generator-semantic-module/src/generators/app/templates/commitlint.config.js
@@ -5,7 +5,5 @@ module.exports = {<% if (commitlintConfig) { %>
 
   <% } %>// Add your own rules. See http://marionebl.github.io/commitlint
   rules: {
-    // Disable language rule
-    lang: [0, 'always', 'eng']
   }
 };


### PR DESCRIPTION
The language rule was removed from bundled commitlint configuration in release 4.3.: https://github.com/marionebl/commitlint/releases/tag/v4.3.0, the override should be unnecessary by now.